### PR TITLE
Update Vancouver.XSL

### DIFF
--- a/styles/Vancouver.XSL
+++ b/styles/Vancouver.XSL
@@ -1006,7 +1006,7 @@
       </xsl:choose>
     </xsl:variable>
 
-    <td align="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/halign=left}" style="white-space:nowrap; width:30px; vertical-align:top;" valign="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/valign}">
+    <td align="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/halign=left}" style="white-space:nowrap; width:40px; vertical-align:top;" valign="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/valign}">
       <p class="MsoBibliography">
 
         <xsl:variable name="columnX">

--- a/styles/Vancouver.XSL
+++ b/styles/Vancouver.XSL
@@ -1006,7 +1006,7 @@
       </xsl:choose>
     </xsl:variable>
 
-    <td nowrap align="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/halign}" valign="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/valign}">
+    <td align="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/halign}" style="white-space:nowrap; width:237px; vertical-align:top;" valign="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/valign}">
       <p class="MsoBibliography">
 
         <xsl:variable name="columnX">

--- a/styles/Vancouver.XSL
+++ b/styles/Vancouver.XSL
@@ -1006,7 +1006,7 @@
       </xsl:choose>
     </xsl:variable>
 
-    <td align="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/halign=left}" style="white-space:nowrap; width:40px; vertical-align:top;" valign="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/valign}">
+    <td align="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/halign=left}" style="white-space:nowrap; width:45px; vertical-align:top;" valign="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/valign}">
       <p class="MsoBibliography">
 
         <xsl:variable name="columnX">

--- a/styles/Vancouver.XSL
+++ b/styles/Vancouver.XSL
@@ -1006,7 +1006,7 @@
       </xsl:choose>
     </xsl:variable>
 
-    <td align="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/halign}" style="white-space:nowrap; width:237px; vertical-align:top;" valign="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/valign}">
+    <td align="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/halign}" style="white-space:nowrap; width:50px; vertical-align:top;" valign="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/valign}">
       <p class="MsoBibliography">
 
         <xsl:variable name="columnX">

--- a/styles/Vancouver.XSL
+++ b/styles/Vancouver.XSL
@@ -1006,7 +1006,7 @@
       </xsl:choose>
     </xsl:variable>
 
-    <td align="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/halign}" style="white-space:nowrap; width:50px; vertical-align:top;" valign="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/valign}">
+    <td align="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/halign}" style="white-space:nowrap; width:25px; vertical-align:top;" valign="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/valign}">
       <p class="MsoBibliography">
 
         <xsl:variable name="columnX">

--- a/styles/Vancouver.XSL
+++ b/styles/Vancouver.XSL
@@ -1006,7 +1006,7 @@
       </xsl:choose>
     </xsl:variable>
 
-    <td align="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/halign=left}" style="white-space:nowrap; width:50px; vertical-align:top;" valign="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/valign}">
+    <td align="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/halign=left}" style="white-space:nowrap; width:30px; vertical-align:top;" valign="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/valign}">
       <p class="MsoBibliography">
 
         <xsl:variable name="columnX">

--- a/styles/Vancouver.XSL
+++ b/styles/Vancouver.XSL
@@ -1006,7 +1006,7 @@
       </xsl:choose>
     </xsl:variable>
 
-    <td align="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/halign}" style="white-space:nowrap; width:25px; vertical-align:top;" valign="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/valign}">
+    <td align="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/halign=left}" style="white-space:nowrap; width:50px; vertical-align:top;" valign="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/valign}">
       <p class="MsoBibliography">
 
         <xsl:variable name="columnX">

--- a/styles/Vancouver.XSL
+++ b/styles/Vancouver.XSL
@@ -1006,7 +1006,7 @@
       </xsl:choose>
     </xsl:variable>
 
-    <td align="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/halign}" valign="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/valign}">
+    <td nowrap align="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/halign}" valign="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/valign}">
       <p class="MsoBibliography">
 
         <xsl:variable name="columnX">


### PR DESCRIPTION
Resolved:
Stopping double digit reference id from text wrapping in bibliography:
Used <td style="white-space:nowrap; width:237px; vertical-align:top;">