### PR TITLE
Update Vancouver.XSL

### DIFF
--- a/styles/Vancouver.XSL
+++ b/styles/Vancouver.XSL
@@ -1006,7 +1006,7 @@
       </xsl:choose>
     </xsl:variable>
 
-    <td align="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/halign=left}" style="white-space:nowrap; width:45px; vertical-align:top;" valign="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/valign}">
+    <td align="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/halign=left}" style="white-space:nowrap; width:46px; vertical-align:top;" valign="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/valign}">
       <p class="MsoBibliography">
 
         <xsl:variable name="columnX">

--- a/styles/Vancouver.XSL
+++ b/styles/Vancouver.XSL
@@ -151,8 +151,8 @@
       </source>
     </importantfields>
     <citation>
-      <openbracket>(</openbracket>
-      <closebracket>)</closebracket>
+      <openbracket>[</openbracket>
+      <closebracket>]</closebracket>
       <separator>,</separator>
       <source type="Book">
         <format>{%RefOrder%}</format>
@@ -192,6 +192,8 @@
       <columns>2</columns>
       <source type="Book">
         <column id="1">
+             <openbracket>[</openbracket>
+      <closebracket>]</closebracket>
           <halign>right</halign>
           <valign>top</valign>
           <format>{%RefOrder%.}</format>
@@ -218,6 +220,8 @@
       </source>
       <source type="JournalArticle">
         <column id="1">
+             <openbracket>[</openbracket>
+      <closebracket>]</closebracket>
           <halign>right</halign>
           <valign>top</valign>
           <format>{%RefOrder%.}</format>
@@ -244,6 +248,8 @@
       </source>
       <source type="ConferenceProceedings">
         <column id="1">
+             <openbracket>[</openbracket>
+      <closebracket>]</closebracket> 
           <halign>right</halign>
           <valign>top</valign>
           <format>{%RefOrder%.}</format>
@@ -257,6 +263,8 @@
       </source>
       <source type="Report">
         <column id="1">
+             <openbracket>[</openbracket>
+      <closebracket>]</closebracket>
           <halign>right</halign>
           <valign>top</valign>
           <format>{%RefOrder%.}</format>
@@ -270,6 +278,8 @@
       </source>
       <source type="InternetSite">
         <column id="1">
+             <openbracket>[</openbracket>
+      <closebracket>]</closebracket>
           <halign>right</halign>
           <valign>top</valign>
           <format>{%RefOrder%.}</format>
@@ -283,6 +293,8 @@
       </source>
       <source type="DocumentFromInternetSite">
         <column id="1">
+             <openbracket>[</openbracket>
+      <closebracket>]</closebracket>
           <halign>right</halign>
           <valign>top</valign>
           <format>{%RefOrder%.}</format>
@@ -322,6 +334,8 @@
       </source>
       <source type="Misc">
         <column id="1">
+             <openbracket>[</openbracket>
+      <closebracket>]</closebracket>
           <halign>right</halign>
           <valign>top</valign>
           <format>{%RefOrder%.}</format>
@@ -335,6 +349,8 @@
       </source>
       <source type="Thesis">
         <column id="1">
+             <openbracket>[</openbracket>
+      <closebracket>]</closebracket>
           <halign>right</halign>
           <valign>top</valign>
           <format>{%RefOrder%.}</format>


### PR DESCRIPTION
1) Changed int-text citation formatting from curly brackets to square brackets.
Before: Text in document (14) cites like this.
Now: Text in document [14] cites like this.

2) Stopped double digit text wrapping in bibliography - numbers now correctly aligned
Before: 
    9. Author. Source title. Other data....
    1
    0. Author. Source title. Other data....
    1
    1. Author. Source title. Other data....
Now: 
    9. Author. Source title. Other data....
    10. Author. Source title. Other data....
    11. Author. Source title. Other data....