### PR TITLE
Tkwoodstock patch 6

### DIFF
--- a/styles/Vancouver.XSL
+++ b/styles/Vancouver.XSL
@@ -1022,7 +1022,7 @@
       </xsl:choose>
     </xsl:variable>
 
-    <td align="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/halign=left}" style="white-space:nowrap; width:20px; vertical-align:top;" valign="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/valign}">
+    <td align="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/halign=left}" style="white-space:nowrap; width:10px; vertical-align:top;" valign="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/valign}">
       <p class="MsoBibliography">
 
         <xsl:variable name="columnX">

--- a/styles/Vancouver.XSL
+++ b/styles/Vancouver.XSL
@@ -1022,7 +1022,7 @@
       </xsl:choose>
     </xsl:variable>
 
-    <td align="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/halign=left}" style="white-space:nowrap; width:5px; vertical-align:top;" valign="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/valign}">
+    <td align="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/halign=left}" style="white-space:nowrap; width:15px; vertical-align:top;" valign="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/valign}">
       <p class="MsoBibliography">
 
         <xsl:variable name="columnX">

--- a/styles/Vancouver.XSL
+++ b/styles/Vancouver.XSL
@@ -1022,7 +1022,7 @@
       </xsl:choose>
     </xsl:variable>
 
-    <td align="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/halign=left}" style="white-space:nowrap; width:10px; vertical-align:top;" valign="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/valign}">
+    <td align="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/halign=left}" style="white-space:nowrap; width:5px; vertical-align:top;" valign="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/valign}">
       <p class="MsoBibliography">
 
         <xsl:variable name="columnX">

--- a/styles/Vancouver.XSL
+++ b/styles/Vancouver.XSL
@@ -1022,7 +1022,7 @@
       </xsl:choose>
     </xsl:variable>
 
-    <td align="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/halign=left}" style="white-space:nowrap; width:46px; vertical-align:top;" valign="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/valign}">
+    <td align="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/halign=left}" style="white-space:nowrap; width:20px; vertical-align:top;" valign="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/valign}">
       <p class="MsoBibliography">
 
         <xsl:variable name="columnX">

--- a/styles/Vancouver.XSL
+++ b/styles/Vancouver.XSL
@@ -1022,7 +1022,7 @@
       </xsl:choose>
     </xsl:variable>
 
-    <td align="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/halign=left}" style="white-space:nowrap; width:15px; vertical-align:top;" valign="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/valign}">
+    <td align="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/halign=left}" style="white-space:nowrap; width:45px; vertical-align:top;" valign="{$params/bibliography/source[@type = $type]/column[@id = $columnId]/valign}">
       <p class="MsoBibliography">
 
         <xsl:variable name="columnX">


### PR DESCRIPTION
Changes A), B) and C) have been made to original code of Vancouver referencing, other general formatting improvements have also been implemented.

A) Changed int-text citation formatting from curly brackets to square brackets.
Before: 
Text in document (14) cites like this.
Now: 
Text in document [14] cites like this.


B) Stopped double digit text wrapping in bibliography - numbers now correctly aligned
Before:
9. Author. Source title. Other data...
1
0. Author. Source title. Other data...
1
1. Author. Source title. Other data...
Now:
Author. Source title. Other data....
Author. Source title. Other data....
Author. Source title. Other data....


C) Added bracket to date accessed item in bibliography.
Before: 
6. Author. Source title. Other data... [date accessed: 3rd July 2023
Now:
6. Author. Source title. Other data... [date accessed: 3rd July 2023]

